### PR TITLE
Update list-of-css-features.md

### DIFF
--- a/list-of-css-features.md
+++ b/list-of-css-features.md
@@ -541,6 +541,16 @@ that were discussed
 </details>
 
 <details>
+  <summary>Misc</summary>
+
+| Property                                                                                    | Notes |
+|---------------------------------------------------------------------------------------------|-------|
+| [Nesting](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_nesting/Using_CSS_nesting)   |       |
+
+</details>
+
+
+<details>
   <summary>Pseudo-classes</summary>
 
 | Property                                                                                                  | Notes |


### PR DESCRIPTION
Nesting was missing as mentioned by [this comment](https://github.com/CSS-Next/css-next/discussions/92#discussioncomment-9438869).

There was no proper group to add it so added _Misc_ as we already have such a group in CSS4.